### PR TITLE
ENH: Move to similar github actions as cookbooks

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -1,0 +1,75 @@
+name: build-book
+
+on:
+  workflow_call:
+    inputs:
+      environment_name:
+        description: 'Name of conda environment to activate'
+        required: false
+        default: 'ams-open-radar-2023-dev'
+        type: string
+      environment_file:
+        description: 'Name of conda environment file'
+        required: false
+        default: 'environment.yml'
+        type: string
+      path_to_notebooks:
+        description: 'Location of the JupyterBook source relative to repo root'
+        required: false
+        default: './notebooks'
+        type: string
+      use_cached_environment:
+        description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
+        required: false
+        default: 'true'
+        type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout files in repo
+        uses: actions/checkout@main
+      - name: remove Dockerfile
+        run: |
+          rm binder/Dockerfile
+      - name: update jupyter dependencies with repo2docker
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          DOCKER_USERNAME: "openradar"
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REGISTRY: "ghcr.io"
+          PUBLIC_REGISTRY_CHECK: true
+          APPENDIX_FILE: "binder/appendix.txt"
+
+  build-book:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openradar/ams-open-radar-2023:latest
+      options: --user root
+    needs: [build-container]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the book
+        run: |
+          # copy baltrad notebooks to book dir
+          cp -rp /home/jovyan/notebooks/baltrad* notebooks/.
+          cp -rp /home/jovyan/notebooks/pyart2baltrad* notebooks/.
+          install/nbstripout_notebooks.sh
+          jupyter-book build ${{ inputs.path_to_notebooks }}
+      - name: Zip the book
+        run: |
+          set -x
+          set -e
+          if [ -f book.zip ]; then
+              rm -rf book.zip
+          fi
+          zip -r book.zip ${{ inputs.path_to_notebooks }}/_build/html
+      - name: Upload zipped book artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: book-zip-${{github.event.number}}
+          path: ./book.zip

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -27,6 +27,9 @@ on:
 jobs:
   build-container:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: checkout files in repo
         uses: actions/checkout@main

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -21,7 +21,7 @@ jobs:
           APPENDIX_FILE: "binder/appendix.txt"
   build:
     if: ${{ github.repository_owner == 'openradar' }}
-    uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
+    uses: ./.github/workflows/build-book.yaml
     with:
       environment_name: ams-open-radar-2023-dev
 

--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -9,11 +9,9 @@ on:
 
 jobs:
   build:
-    uses: ./.github/workflows/build-book-pullrequest.yaml
+    uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name: ams-open-radar-2023-dev
-      environment_file: environment.yml
-      use_cached_environment: 'false'
 
   deploy:
     needs: build

--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -12,6 +12,7 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name: ams-open-radar-2023-dev
+      use_cached_environment: 'false'
 
   deploy:
     needs: build

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
+    uses: ./.github/workflows/build-book.yaml
     with:
       environment_name: ams-open-radar-2023-dev
       use_cached_environment: 'false'

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -7,4 +7,5 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name: ams-open-radar-2023-dev
+      use_cached_environment: 'false'
       artifact_name: book-zip-${{ github.event.number }}

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -8,4 +8,3 @@ jobs:
     with:
       environment_name: ams-open-radar-2023-dev
       use_cached_environment: 'false'
-      artifact_name: book-zip-${{ github.event.number }}

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -4,9 +4,7 @@ on:
 
 jobs:
   build:
-    uses: ./.github/workflows/build-book-pullrequest.yaml
+    uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name: ams-open-radar-2023-dev
-      environment_file: environment.yml
-      path_to_notebooks: ./
-      use_cached_environment: 'false'  # This is default, not strickly needed. Set to 'false' to always build a new environment
+      artifact_name: book-zip-${{ github.event.number }}

--- a/.github/workflows/trigger-link-check.yaml
+++ b/.github/workflows/trigger-link-check.yaml
@@ -5,3 +5,4 @@ on:
 jobs:
   link-check:
     uses: ProjectPythia/cookbook-actions/.github/workflows/link-checker.yaml@main
+    

--- a/.github/workflows/trigger-preview.yaml
+++ b/.github/workflows/trigger-preview.yaml
@@ -15,6 +15,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
     with:
+      environment_name: ams-open-radar-2023
       artifact_name: book-zip-${{ needs.find-pull-request.outputs.number }}
       destination_dir: _preview/${{ needs.find-pull-request.outputs.number }} # deploy to subdirectory labeled with PR number
       is_preview: "true"

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ tags:
 execute:
   # To execute notebooks via a binder instead, replace 'cache' with 'binder'
   execute_notebooks: 'binder'
-  timeout: 1200
+  timeout: 1800
   allow_errors: True # cells with expected failures must set the `raises-exception` cell tag
 
 # Add a few extensions to help with parsing content

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ tags:
 
 execute:
   # To execute notebooks via a binder instead, replace 'cache' with 'binder'
-  execute_notebooks: 'auto'
+  execute_notebooks: 'binder'
   timeout: 1200
   allow_errors: True # cells with expected failures must set the `raises-exception` cell tag
 

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ tags:
 
 execute:
   # To execute notebooks via a binder instead, replace 'cache' with 'binder'
-  execute_notebooks: 'binder'
+  execute_notebooks: 'cache'
   timeout: 1800
   allow_errors: True # cells with expected failures must set the `raises-exception` cell tag
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,0 @@
-FROM ghcr.io/openradar/ams-open-radar-2023:latest

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/openradar/ams-open-radar-2023:latest

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,6 @@ dependencies:
   - xradar
   - cartopy
   - metpy
-  - hvplot
-  - holoviews
   - pydda
   - s3fs
   - geoviews

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - pyviz
 dependencies:
-  - python>=3.10
+  - python
   - jupyter-book
   - jupyterlab
   - jupyter_server<2


### PR DESCRIPTION
Use binder for execution and shift to new github actions