### PR TITLE
ADD: Some final fixes to the PyDDA tutorial

### DIFF
--- a/notebooks/pydda/Retrieving_winds_with_pydda.ipynb
+++ b/notebooks/pydda/Retrieving_winds_with_pydda.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "We will examine the same case study over Northern Alabama that has been used for this entire short course. For this case in April 2008, we had an MCS with supercells out ahead of the main line approach the Huntsville, AL region. 3D variational retrievals of thunderstorm updrafts can have uncertainties on the order of 5 m/s. In addition these retrievals require precipitation coverage throughout the domain. Therefore, 3DVAR retrievals are best suited for deep convection like this where the updrafts are strong and precipitation coverage is wide.\n",
     "\n",
-    "For this case, we had coverage of the storm from two radars, the ARMOR and the Huntsville NEXRAD radar "
+    "For this case, we had coverage of the storm from two radars, the ARMOR and the Huntsville NEXRAD radar."
    ]
   },
   {
@@ -284,7 +284,7 @@
    "source": [
     "## Gridding\n",
     "\n",
-    "PyDDA requires data to be gridded to Cartesian coordinates in order to retrieve the 3D wind fields. Therefore, we will use Py-ART's *grid_from_radars* function in order to do the gridding. You usually want to have a grid resolution such that your features of interest are covered by four grid points. In this case, we're at 1 km horizontal and 0.5 km vertical resolution. (Ask if we are covering gridding in Py-ART and wait for link here)"
+    "PyDDA requires data to be gridded to Cartesian coordinates in order to retrieve the 3D wind fields. Therefore, we will use Py-ART's *grid_from_radars* function in order to do the gridding. You usually want to have a grid resolution such that your features of interest are covered by four grid points. In this case, we're at 1 km horizontal and 0.5 km vertical resolution. For more information on gridding with Py-ART, see the Radar Cookbook."
    ]
   },
   {
@@ -1613,7 +1613,7 @@
     "| mask_outside_opt | Mask all winds outside the Dual Doppler lobes | True\n",
     "| vel_name| The name of the velocity field in the radar data | 'corrected_velocity' |\n",
     "| wind_tol | Stop optimization when the change in wind speeds between iterations is less than this value |\n",
-    "| engine | PyDDA supports three backends for optimization: SciPy, JAX, and TensorFlow. We highly recommend the TensorFlow backend to take advantage of parallelism and GPUs for retrieval. | \"tensorflow\""
+    "| engine | PyDDA supports three backends for optimization: SciPy, JAX, and TensorFlow. | \"scipy\""
    ]
   },
   {


### PR DESCRIPTION
I've changed the default engine setting in the markdown documents to "scipy." In addition, links to the gridding and dealiasing parts of the tutorial have been added to the relevant section for the user to quickly click back to.