### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pydda
   - s3fs
   - tobac
-  - pyrad_mch
+  - pyrad_arm
   - geoviews
   - tensorflow-probability
   - tobac


### PR DESCRIPTION
I realized there is a chance that requiring pyrad_mch will trigger the installation of theMeteoSwiss Py-ART fork which is unwanted. Hence I replaced it with another package that relies on the official Py-ART version, as was done for the erad2022 course.

Sorry for forgetting this!